### PR TITLE
Converted to october-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "keios/multisite",
+    "type": "october-plugin",
     "description": "Plugin for OctoberCMS allowing to assign different theme to different domains",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Hi.

To be able to install multisite as a plugin through composer, the type october-plugin is needed.

Thank you for the plugin.